### PR TITLE
[Mayur] rename LOG_LEVEL to log.level

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="${LOG_LEVEL:-INFO}">
+    <root level="${log.level:-INFO}">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Purpose: To make it consistent with other configs