### PR TITLE
fix: bookmark for firehose configurations

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,15 +4,15 @@ This page contains reference for all the application configurations for Firehose
 
 ## Table of Contents
 
-* [Generic](configuration.md#-generic)
-* [HTTP Sink](configuration.md#-http-sink)
-* [JDBC Sink](configuration.md#-jdbc-sink)
-* [Influx Sink](configuration.md#-influx-sink)
-* [Redis Sink](configuration.md#-redis-sink)
-* [Elasticsearch Sink](configuration.md#-elasticsearch-sink)
-* [GRPC Sink](configuration.md#-grpc-sink)
-* [Prometheus Sink](configuration.md#-prometheus-sink)
-* [Standard](configuration.md#-standard)
+* [Generic](configuration.md#generic)
+* [HTTP Sink](configuration.md#http-sink)
+* [JDBC Sink](configuration.md#jdbc-sink)
+* [Influx Sink](configuration.md#influx-sink)
+* [Redis Sink](configuration.md#redis-sink)
+* [Elasticsearch Sink](configuration.md#elasticsearch-sink)
+* [GRPC Sink](configuration.md#grpc-sink)
+* [Prometheus Sink](configuration.md#prometheus-sink)
+* [Standard](configuration.md#standard)
 
 ## Generic
 


### PR DESCRIPTION
Current configuration link contains -, which should not be part of url in order to go at bookmark.