### PR TITLE
fix: Connections in jdbc sink are returned to pool rather than being recreated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ lombok {
 }
 
 group 'io.odpf'
-version '1.2.2'
+version '1.2.3'
 
 
 def projName = "firehose"

--- a/src/main/java/io/odpf/firehose/sink/jdbc/HikariJdbcConnectionPool.java
+++ b/src/main/java/io/odpf/firehose/sink/jdbc/HikariJdbcConnectionPool.java
@@ -1,7 +1,7 @@
 package io.odpf.firehose.sink.jdbc;
 
 import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.pool.HikariPool;
+import com.zaxxer.hikari.HikariDataSource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -13,8 +13,7 @@ public class HikariJdbcConnectionPool implements JdbcConnectionPool {
 
     private static final Integer CONNECTION_TIMEOUT_THRESHOLD = 250;
     private static final Integer IDLE_TIMEOUT_THRESHOLD = 0;
-
-    private HikariPool hikariPool;
+    private final HikariDataSource hikariDataSource;
 
     /**
      * Instantiates a new Hikari jdbc connection pool.
@@ -41,22 +40,25 @@ public class HikariJdbcConnectionPool implements JdbcConnectionPool {
         if (idleTimeout >= IDLE_TIMEOUT_THRESHOLD) {
             config.setIdleTimeout(idleTimeout);
         }
-        this.hikariPool = new HikariPool(config);
+        hikariDataSource = new HikariDataSource(config);
+    }
 
+    HikariJdbcConnectionPool(HikariDataSource hikariDataSource) {
+        this.hikariDataSource = hikariDataSource;
     }
 
     @Override
-    public Connection get() throws SQLException {
-        return hikariPool.getConnection();
+    public Connection getConnection() throws SQLException {
+        return hikariDataSource.getConnection();
     }
 
     @Override
-    public void release(Connection connection) {
-        hikariPool.evictConnection(connection);
+    public void release(Connection connection) throws SQLException {
+        connection.close();
     }
 
     @Override
-    public void shutdown() throws InterruptedException {
-        hikariPool.shutdown();
+    public void shutdown() {
+        hikariDataSource.close();
     }
 }

--- a/src/main/java/io/odpf/firehose/sink/jdbc/JdbcConnectionPool.java
+++ b/src/main/java/io/odpf/firehose/sink/jdbc/JdbcConnectionPool.java
@@ -13,14 +13,14 @@ public interface JdbcConnectionPool {
      * @return the connection
      * @throws SQLException the sql exception
      */
-    Connection get() throws SQLException;
+    Connection getConnection() throws SQLException;
 
     /**
      * Release the connection held.
      *
      * @param connection the connection
      */
-    void release(Connection connection);
+    void release(Connection connection) throws SQLException;
 
     /**
      * Shutdown the connection pool.

--- a/src/main/java/io/odpf/firehose/sink/jdbc/JdbcSink.java
+++ b/src/main/java/io/odpf/firehose/sink/jdbc/JdbcSink.java
@@ -42,10 +42,16 @@ public class JdbcSink extends AbstractSink {
         this.stencilClient = stencilClient;
     }
 
+    JdbcSink(Instrumentation instrumentation, String sinkType, JdbcConnectionPool pool, QueryTemplate queryTemplate, StencilClient stencilClient, Statement statement, Connection connection) {
+        this(instrumentation, sinkType, pool, queryTemplate, stencilClient);
+        this.statement = statement;
+        this.connection = connection;
+    }
+
     @Override
     protected void prepare(List<Message> messages) throws SQLException {
         List<String> queriesList = createQueries(messages);
-        connection = pool.get();
+        connection = pool.getConnection();
         statement = connection.createStatement();
 
         for (String query : queriesList) {

--- a/src/test/java/io/odpf/firehose/sink/jdbc/HikariJdbcConnectionPoolTest.java
+++ b/src/test/java/io/odpf/firehose/sink/jdbc/HikariJdbcConnectionPoolTest.java
@@ -1,0 +1,48 @@
+package io.odpf.firehose.sink.jdbc;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HikariJdbcConnectionPoolTest {
+    @Mock
+    private HikariDataSource hikariDataSource;
+    @Mock
+    private Connection connection;
+
+    private JdbcConnectionPool jdbcConnectionPool;
+
+    @Before
+    public void setup() {
+        jdbcConnectionPool = new HikariJdbcConnectionPool(hikariDataSource);
+    }
+
+    @Test
+    public void shouldGetConnectionFromDataSource() throws SQLException {
+        jdbcConnectionPool.getConnection();
+
+        Mockito.verify(hikariDataSource).getConnection();
+    }
+
+    @Test
+    public void shouldCloseTheConnectionWhenReleased() throws SQLException {
+        jdbcConnectionPool.release(connection);
+
+        Mockito.verify(connection).close();
+    }
+
+    @Test
+    public void shouldCloseDataSourceWhenShutdown() throws SQLException, InterruptedException {
+        jdbcConnectionPool.shutdown();
+
+        Mockito.verify(hikariDataSource).close();
+    }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fixes this bug: https://github.com/odpf/firehose/issues/53

#### :heavy_check_mark: Checklist

- [X] Tests for new functionality and regression tests for bug fixes