### PR TITLE
fix: inputstream of httpbody should be read only once

### DIFF
--- a/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
+++ b/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
@@ -14,7 +14,6 @@ import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,13 +49,13 @@ public abstract class AbstractHttpSink extends AbstractSink {
                 List<String> contentStringList = null;
                 getInstrumentation().logInfo("Response Status: {}", statusCode(response));
                 if (shouldLogRequest(response)) {
-                    contentStringList = readContent(httpRequest.getEntity().getContent());
+                    contentStringList = readContent(httpRequest);
                     printRequest(httpRequest, contentStringList);
                 }
                 if (shouldRetry(response)) {
                     throw new NeedToRetry(statusCode(response));
                 } else if (!Pattern.compile(SUCCESS_CODE_PATTERN).matcher(String.valueOf(response.getStatusLine().getStatusCode())).matches()) {
-                    contentStringList = contentStringList == null ? readContent(httpRequest.getEntity().getContent()) : contentStringList;
+                    contentStringList = contentStringList == null ? readContent(httpRequest) : contentStringList;
                     captureMessageDropCount(response, contentStringList);
                 }
             } catch (IOException e) {
@@ -119,7 +118,7 @@ public abstract class AbstractHttpSink extends AbstractSink {
         getInstrumentation().logInfo(entireRequest);
     }
 
-    protected abstract List<String> readContent(InputStream inputStream) throws IOException;
+    protected abstract List<String> readContent(HttpEntityEnclosingRequestBase httpRequest) throws IOException;
 
     protected abstract void captureMessageDropCount(HttpResponse response, List<String> contentString) throws IOException;
 

--- a/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
+++ b/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
@@ -47,14 +47,17 @@ public abstract class AbstractHttpSink extends AbstractSink {
         for (HttpEntityEnclosingRequestBase httpRequest : httpRequests) {
             try {
                 response = httpClient.execute(httpRequest);
+                List<String> contentStringList = null;
                 getInstrumentation().logInfo("Response Status: {}", statusCode(response));
                 if (shouldLogRequest(response)) {
-                    printRequest(httpRequest);
+                    contentStringList = readContent(httpRequest.getEntity().getContent());
+                    printRequest(httpRequest, contentStringList);
                 }
                 if (shouldRetry(response)) {
                     throw new NeedToRetry(statusCode(response));
                 } else if (!Pattern.compile(SUCCESS_CODE_PATTERN).matcher(String.valueOf(response.getStatusLine().getStatusCode())).matches()) {
-                    captureMessageDropCount(response, httpRequest);
+                    contentStringList = contentStringList == null ? readContent(httpRequest.getEntity().getContent()) : contentStringList;
+                    captureMessageDropCount(response, contentStringList);
                 }
             } catch (IOException e) {
                 NewRelic.noticeError(e);
@@ -107,20 +110,18 @@ public abstract class AbstractHttpSink extends AbstractSink {
     }
 
 
-    private void printRequest(HttpEntityEnclosingRequestBase httpRequest) throws IOException {
-        InputStream inputStream = httpRequest.getEntity().getContent();
+    private void printRequest(HttpEntityEnclosingRequestBase httpRequest, List<String> contentStringList) throws IOException {
         String entireRequest = String.format("\nRequest Method: %s\nRequest Url: %s\nRequest Headers: %s\nRequest Body: %s",
                 httpRequest.getMethod(),
                 httpRequest.getURI(),
                 Arrays.asList(httpRequest.getAllHeaders()),
-                Strings.join(readContent(inputStream), "\n"));
+                Strings.join(contentStringList, "\n"));
         getInstrumentation().logInfo(entireRequest);
-        inputStream.reset();
     }
 
     protected abstract List<String> readContent(InputStream inputStream) throws IOException;
 
-    protected abstract void captureMessageDropCount(HttpResponse response, HttpEntityEnclosingRequestBase httpRequest) throws IOException;
+    protected abstract void captureMessageDropCount(HttpResponse response, List<String> contentString) throws IOException;
 
     public void setHttpRequests(List<HttpEntityEnclosingRequestBase> httpRequests) {
         this.httpRequests.clear();

--- a/src/main/java/io/odpf/firehose/sink/http/HttpSink.java
+++ b/src/main/java/io/odpf/firehose/sink/http/HttpSink.java
@@ -8,7 +8,6 @@ import io.odpf.firehose.sink.common.AbstractHttpSink;
 import io.odpf.firehose.sink.http.request.types.Request;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,9 +59,8 @@ public class HttpSink extends AbstractHttpSink {
         return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines().collect(Collectors.toList());
     }
 
-    protected void captureMessageDropCount(HttpResponse response, HttpEntityEnclosingRequestBase httpRequest) throws IOException {
-        InputStream inputStream = httpRequest.getEntity().getContent();
-        String requestBody = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines().collect(Collectors.joining("\n"));
+    protected void captureMessageDropCount(HttpResponse response, List<String> contentStringList) {
+        String requestBody = joptsimple.internal.Strings.join(contentStringList, "\n");
 
         List<String> result = Arrays.asList(requestBody.replaceAll("^\\[|]$", "").split("},\\s*\\{"));
 

--- a/src/main/java/io/odpf/firehose/sink/http/HttpSink.java
+++ b/src/main/java/io/odpf/firehose/sink/http/HttpSink.java
@@ -8,6 +8,7 @@ import io.odpf.firehose.sink.common.AbstractHttpSink;
 import io.odpf.firehose.sink.http.request.types.Request;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,8 +56,10 @@ public class HttpSink extends AbstractHttpSink {
     }
 
     @Override
-    protected List<String> readContent(InputStream inputStream) {
-        return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines().collect(Collectors.toList());
+    protected List<String> readContent(HttpEntityEnclosingRequestBase httpRequest) throws IOException {
+        try (InputStream inputStream = httpRequest.getEntity().getContent()) {
+            return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines().collect(Collectors.toList());
+        }
     }
 
     protected void captureMessageDropCount(HttpResponse response, List<String> contentStringList) {

--- a/src/main/java/io/odpf/firehose/sink/prometheus/PromSink.java
+++ b/src/main/java/io/odpf/firehose/sink/prometheus/PromSink.java
@@ -11,7 +11,6 @@ import io.odpf.firehose.metrics.Instrumentation;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
@@ -61,11 +60,8 @@ public class PromSink extends AbstractHttpSink {
         }
     }
 
-    protected void captureMessageDropCount(HttpResponse response, HttpEntityEnclosingRequestBase httpRequest) throws IOException {
-        InputStream inputStream = httpRequest.getEntity().getContent();
-        List<String> result = readContent(inputStream);
-
-        getInstrumentation().captureCountWithTags(SINK_MESSAGES_DROP_TOTAL, result.size(), "cause= " + statusCode(response));
+    protected void captureMessageDropCount(HttpResponse response, List<String> contentStringList) {
+        getInstrumentation().captureCountWithTags(SINK_MESSAGES_DROP_TOTAL, contentStringList.size(), "cause= " + statusCode(response));
         getInstrumentation().logInfo("Message dropped because of status code: " + statusCode(response));
     }
 

--- a/src/test/java/io/odpf/firehose/sink/http/HttpSinkTest.java
+++ b/src/test/java/io/odpf/firehose/sink/http/HttpSinkTest.java
@@ -188,7 +188,6 @@ public class HttpSinkTest {
         when(httpClient.execute(httpPut)).thenReturn(response);
         when(response.getAllHeaders()).thenReturn(new Header[]{new BasicHeader("Accept", "text/plain")});
         when(response.getEntity()).thenReturn(httpEntity);
-        when(httpEntity.getContent()).thenReturn(new StringInputStream("[{\"key\":\"value1\"},{\"key\":\"value2\"}]"));
 
         HttpSink httpSink = new HttpSink(instrumentation, request, httpClient, stencilClient,
                 retryStatusCodeRange, new RangeToHashMapConverter().convert(null, "400-505"));

--- a/src/test/java/io/odpf/firehose/sink/prometheus/PromSinkTest.java
+++ b/src/test/java/io/odpf/firehose/sink/prometheus/PromSinkTest.java
@@ -306,7 +306,7 @@ public class PromSinkTest {
         PromSink promSink = new PromSink(instrumentation, request, httpClient, stencilClient,
                 retryStatusCodeRange, requestLogStatusCodeRanges);
 
-        List<String> requestBody = promSink.readContent(inputStream);
+        List<String> requestBody = promSink.readContent(httpPost);
         assertEquals(body, requestBody.toString());
     }
 }


### PR DESCRIPTION
Some implementation of inputstream.reset() causes IOException, to avoid it we should read inputstream only once. 