### PR TITLE
refactor: remove X- prefix from custom headers

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -239,6 +239,7 @@ Defines the fully qualified name of the proto class which is to be used for para
 Defines the mapping of the proto fields to header/query fields in JSON format.
 
 * Example value: `{"1":"order_number","2":"event_timestamp","3":"driver_id"}`
+* Example value: `{"1":"event_timestamp","2":{"1":"customer_email"}}` Here field with index 2 is a complex data type 
 * Type: `optional`
 
 ### `SINK_HTTP_OAUTH2_ENABLE`
@@ -314,6 +315,7 @@ Defines the password to connect to DB.
 Defines the mapping of fields in DB and the corresponding proto index from where the value will be extracted. This is a JSON field.
 
 * Example value: `{"6":"customer_id","1":"service_type","5":"event_timestamp"}` Proto field value with index 1 will be stored in a column named service\_type in DB and so on
+* Example value: `{"1":"event_timestamp","2":{"1":"customer_email"}}` Here field with index 2 is a complex data type 
 * Type: `required`
 
 ### `SINK_JDBC_UNIQUE_KEYS`
@@ -458,6 +460,7 @@ The string that will act as the key for each Redis entry. This key can be config
 This is the field that decides what all data will be stored in the HashSet for each message.
 
 * Example value: `{"6":"customer_id",  "2":"order_num"}`
+* Example value: `{"1":"event_timestamp","2":{"1":"customer_email"}}` Here field with index 2 is a complex data type
 * Type: `required (For Hashset)`
 
 ### `SINK_REDIS_LIST_DATA_PROTO_INDEX`

--- a/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
+++ b/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
@@ -57,8 +57,6 @@ public class HeaderBuilder {
     }
 
     private String convertToCustomHeaders(String parameter) {
-        String customHeader = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, parameter);
-        customHeader = "X-" + customHeader;
-        return customHeader;
+        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, parameter);
     }
 }

--- a/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
+++ b/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
@@ -99,7 +99,7 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("X-OrderNumber"));
+        assertEquals("RB_1234", header.get("OrderNumber"));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("X-OrderNumber"));
+        assertEquals("RB_1234", header.get("OrderNumber"));
         assertEquals("json", header.get("content-type"));
     }
 


### PR DESCRIPTION
Change log:
- Removed 'X-' prefix from custom headers, earlier header name 'X-HeaderA' will now be 'HeaderA'
- Updated the documentation with an example value of INPUT_SCHEMA_PROTO_TO_COLUMN_MAPPING where a complex data type field is being used