### PR TITLE
refactor: remove formatting from parameterized header keys

### DIFF
--- a/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
+++ b/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
@@ -3,7 +3,6 @@ package io.odpf.firehose.sink.http.request.header;
 import io.odpf.firehose.config.enums.HttpSinkParameterSourceType;
 import io.odpf.firehose.consumer.Message;
 import io.odpf.firehose.proto.ProtoToFieldMapper;
-import com.google.common.base.CaseFormat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class HeaderBuilder {
                         : message.getLogMessage());
 
         Map<String, String> parameterizedHeaders = paramMap.entrySet().stream()
-                .collect(Collectors.toMap(e -> convertToCustomHeaders(e.getKey()), e -> e.getValue().toString()));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
         baseHeaders.putAll(parameterizedHeaders);
         return baseHeaders;
     }
@@ -54,9 +53,5 @@ public class HeaderBuilder {
         this.protoToFieldMapper = protoToFieldmapper;
         this.httpSinkParameterSourceType = httpSinkParameterSource;
         return this;
-    }
-
-    private String convertToCustomHeaders(String parameter) {
-        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, parameter);
     }
 }

--- a/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
+++ b/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
@@ -91,7 +91,7 @@ public class HeaderBuilderTest {
     @Test
     public void shouldHaveExtraParameterizedHeaderIfParameterizedHeaderEnabled() {
         String headerConfig = "content-type:json";
-        Map<String, Object> mockParamMap = Collections.singletonMap("order_number", "RB_1234");
+        Map<String, Object> mockParamMap = Collections.singletonMap("orderNumber", "RB_1234");
         when(protoToFieldMapper.getFields(message.getLogMessage())).thenReturn(mockParamMap);
 
         HeaderBuilder headerBuilder = new HeaderBuilder(headerConfig)
@@ -99,13 +99,13 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("OrderNumber"));
+        assertEquals("RB_1234", header.get("orderNumber"));
     }
 
     @Test
-    public void shouldKeepBasedHeadersUnchangedAndAddExtraHeaderChangingTheName() {
+    public void shouldKeepBaseHeadersAndAddExtraHeaderAsItIsProvideInTheConfig() {
         String headerConfig = "content-type:json";
-        Map<String, Object> mockParamMap = Collections.singletonMap("order_number", "RB_1234");
+        Map<String, Object> mockParamMap = Collections.singletonMap("X-OrderNumber", "RB_1234");
         when(protoToFieldMapper.getFields(message.getLogMessage())).thenReturn(mockParamMap);
 
         HeaderBuilder headerBuilder = new HeaderBuilder(headerConfig)
@@ -113,7 +113,7 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("OrderNumber"));
+        assertEquals("RB_1234", header.get("X-OrderNumber"));
         assertEquals("json", header.get("content-type"));
     }
 


### PR DESCRIPTION
Refactor:
- Remove formatting of Parameterized http sink header keys