### PR TITLE
feat: remove newrelic and format HTTP headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'io.odpf'
-version '0.1.2'
+version '0.1.3'
 
 def projName = "firehose"
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ def mainClassName = "io.odpf.firehose.launch.Main"
 dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.1.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.1.0'
-    implementation group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '3.31.1'
     implementation group: 'com.timgroup', name: 'java-statsd-client', version: '3.1.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
     implementation group: 'org.aeonbits.owner', name: 'owner', version: '1.0.9'

--- a/src/main/java/io/odpf/firehose/consumer/GenericConsumer.java
+++ b/src/main/java/io/odpf/firehose/consumer/GenericConsumer.java
@@ -8,7 +8,6 @@ import io.odpf.firehose.config.KafkaConsumerConfig;
 import io.odpf.firehose.filter.FilterException;
 import io.odpf.firehose.filter.Filter;
 import io.odpf.firehose.metrics.Instrumentation;
-import com.newrelic.api.agent.Trace;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -75,7 +74,6 @@ public class GenericConsumer {
         return filteredMessage;
     }
 
-    @Trace(dispatcher = true)
     public void commit() {
         offsets.commit(records);
     }

--- a/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
+++ b/src/main/java/io/odpf/firehose/sink/common/AbstractHttpSink.java
@@ -1,8 +1,6 @@
 package io.odpf.firehose.sink.common;
 
 
-import com.newrelic.api.agent.NewRelic;
-import com.newrelic.api.agent.Trace;
 import io.odpf.firehose.consumer.Message;
 import io.odpf.firehose.exception.NeedToRetry;
 import io.odpf.firehose.metrics.Instrumentation;
@@ -46,7 +44,6 @@ public abstract class AbstractHttpSink extends AbstractSink {
     }
 
     @Override
-    @Trace(dispatcher = true)
     public List<Message> execute() throws Exception {
         HttpResponse response = null;
         for (HttpEntityEnclosingRequestBase httpRequest : httpRequests) {
@@ -67,9 +64,6 @@ public abstract class AbstractHttpSink extends AbstractSink {
                     contentStringList = contentStringList == null ? readContent(httpRequest) : contentStringList;
                     captureMessageDropCount(response, contentStringList);
                 }
-            } catch (IOException e) {
-                NewRelic.noticeError(e);
-                throw e;
             } finally {
                 consumeResponse(response);
                 captureHttpStatusCount(httpRequest, response);

--- a/src/main/java/io/odpf/firehose/sink/grpc/client/GrpcClient.java
+++ b/src/main/java/io/odpf/firehose/sink/grpc/client/GrpcClient.java
@@ -5,7 +5,6 @@ package io.odpf.firehose.sink.grpc.client;
 import io.odpf.firehose.config.GrpcSinkConfig;
 import io.odpf.firehose.metrics.Instrumentation;
 import com.google.protobuf.DynamicMessage;
-import com.newrelic.api.agent.Trace;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -45,7 +44,6 @@ public class GrpcClient {
         this.managedChannel = managedChannel;
     }
 
-    @Trace(dispatcher = true)
     public DynamicMessage execute(byte[] logMessage, Headers headers) {
 
         MethodDescriptor.Marshaller<byte[]> marshaller = getMarshaller();

--- a/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
+++ b/src/main/java/io/odpf/firehose/sink/http/request/header/HeaderBuilder.java
@@ -3,7 +3,6 @@ package io.odpf.firehose.sink.http.request.header;
 import io.odpf.firehose.config.enums.HttpSinkParameterSourceType;
 import io.odpf.firehose.consumer.Message;
 import io.odpf.firehose.proto.ProtoToFieldMapper;
-import com.google.common.base.CaseFormat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class HeaderBuilder {
                         : message.getLogMessage());
 
         Map<String, String> parameterizedHeaders = paramMap.entrySet().stream()
-                .collect(Collectors.toMap(e -> convertToCustomHeaders(e.getKey()), e -> e.getValue().toString()));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
         baseHeaders.putAll(parameterizedHeaders);
         return baseHeaders;
     }
@@ -54,9 +53,5 @@ public class HeaderBuilder {
         this.protoToFieldMapper = protoToFieldmapper;
         this.httpSinkParameterSourceType = httpSinkParameterSource;
         return this;
-    }
-
-    private String convertToCustomHeaders(String parameter) {
-        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, parameter);
     }
 }

--- a/src/main/java/io/odpf/firehose/sink/jdbc/JdbcSink.java
+++ b/src/main/java/io/odpf/firehose/sink/jdbc/JdbcSink.java
@@ -4,7 +4,6 @@ package io.odpf.firehose.sink.jdbc;
 import io.odpf.firehose.consumer.Message;
 import io.odpf.firehose.metrics.Instrumentation;
 import io.odpf.firehose.sink.AbstractSink;
-import com.newrelic.api.agent.Trace;
 import com.gojek.de.stencil.client.StencilClient;
 
 import java.io.IOException;
@@ -71,7 +70,6 @@ public class JdbcSink extends AbstractSink {
     }
 
     @Override
-    @Trace(dispatcher = true)
     protected List<Message> execute() throws Exception {
         try {
             int[] updateCounts = statement.executeBatch();

--- a/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
+++ b/src/test/java/io/odpf/firehose/sink/http/request/header/HeaderBuilderTest.java
@@ -91,7 +91,7 @@ public class HeaderBuilderTest {
     @Test
     public void shouldHaveExtraParameterizedHeaderIfParameterizedHeaderEnabled() {
         String headerConfig = "content-type:json";
-        Map<String, Object> mockParamMap = Collections.singletonMap("order_number", "RB_1234");
+        Map<String, Object> mockParamMap = Collections.singletonMap("orderNumber", "RB_1234");
         when(protoToFieldMapper.getFields(message.getLogMessage())).thenReturn(mockParamMap);
 
         HeaderBuilder headerBuilder = new HeaderBuilder(headerConfig)
@@ -99,13 +99,13 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("OrderNumber"));
+        assertEquals("RB_1234", header.get("orderNumber"));
     }
 
     @Test
-    public void shouldKeepBasedHeadersUnchangedAndAddExtraHeaderChangingTheName() {
+    public void shouldKeepBaseHeadersAndAddExtraHeaderAsItIsProvideInTheConfig() {
         String headerConfig = "content-type:json";
-        Map<String, Object> mockParamMap = Collections.singletonMap("order_number", "RB_1234");
+        Map<String, Object> mockParamMap = Collections.singletonMap("X-OrderNumber", "RB_1234");
         when(protoToFieldMapper.getFields(message.getLogMessage())).thenReturn(mockParamMap);
 
         HeaderBuilder headerBuilder = new HeaderBuilder(headerConfig)
@@ -113,7 +113,7 @@ public class HeaderBuilderTest {
 
         Map<String, String> header = headerBuilder.build(message);
 
-        assertEquals("RB_1234", header.get("OrderNumber"));
+        assertEquals("RB_1234", header.get("X-OrderNumber"));
         assertEquals("json", header.get("content-type"));
     }
 


### PR DESCRIPTION
Refactor:
- Remove newRelic library and its references
- Remove formatting from parameterized HTTP header keys