### PR TITLE
fix: firehose prevented from exiting when out of memory error happened

### DIFF
--- a/src/main/java/io/odpf/firehose/launch/Main.java
+++ b/src/main/java/io/odpf/firehose/launch/Main.java
@@ -50,8 +50,8 @@ public class Main {
                             }
                             firehoseConsumer.process();
                         }
-                    } catch (Exception e) {
-                        instrumentation.captureFatalError(e, "Exception on creating the consumer, exiting the application");
+                    } catch (Exception | Error e) {
+                        instrumentation.captureFatalError(e, "Caught exception or error, exiting the application");
                         System.exit(1);
                     } finally {
                         ensureThreadInterruptStateIsClearedAndClose(firehoseConsumer, instrumentation);

--- a/src/main/java/io/odpf/firehose/metrics/Instrumentation.java
+++ b/src/main/java/io/odpf/firehose/metrics/Instrumentation.java
@@ -129,9 +129,14 @@ public class Instrumentation {
         captureNonFatalError(e);
     }
 
-    public void captureFatalError(Exception e) {
+    public void captureFatalError(Throwable e) {
         logger.error(e.getMessage(), e);
         statsDReporter.recordEvent(ERROR_EVENT, FATAL_ERROR, errorTag(e, FATAL_ERROR));
+    }
+
+    public void captureFatalError(Throwable e, String message) {
+        logger.error(message);
+        this.captureFatalError(e);
     }
 
     public void captureFatalError(Exception e, String message) {
@@ -144,7 +149,7 @@ public class Instrumentation {
         this.captureFatalError(e);
     }
 
-    private String errorTag(Exception e, String errorType) {
+    private String errorTag(Throwable e, String errorType) {
         return ERROR_MESSAGE_CLASS_TAG + "=" + e.getClass().getName() + ",type=" + errorType;
     }
 

--- a/src/main/java/io/odpf/firehose/sink/blob/writer/WriterOrchestrator.java
+++ b/src/main/java/io/odpf/firehose/sink/blob/writer/WriterOrchestrator.java
@@ -134,6 +134,7 @@ public class WriterOrchestrator implements Closeable {
         objectStorageCheckerScheduler.shutdown();
         remoteUploadScheduler.shutdown();
         writerOrchestratorStatus.setClosed(true);
+        writerOrchestratorStatus.close();
         for (LocalFileWriter writer : timePartitionWriterMap.values()) {
             writer.close();
         }

--- a/src/main/java/io/odpf/firehose/sink/blob/writer/WriterOrchestratorStatus.java
+++ b/src/main/java/io/odpf/firehose/sink/blob/writer/WriterOrchestratorStatus.java
@@ -2,11 +2,13 @@ package io.odpf.firehose.sink.blob.writer;
 
 import lombok.Data;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 
 @Data
-public class WriterOrchestratorStatus {
+public class WriterOrchestratorStatus implements Closeable {
     private boolean isClosed;
     private ScheduledFuture<?> localFileWriterFuture;
     private ScheduledFuture<?> objectStorageWriterFuture;
@@ -44,5 +46,11 @@ public class WriterOrchestratorStatus {
         });
         localFileWriterCompletionChecker.start();
         objectStorageWriterCompletionChecker.start();
+    }
+
+    @Override
+    public void close() throws IOException {
+        localFileWriterCompletionChecker.interrupt();
+        objectStorageWriterCompletionChecker.interrupt();
     }
 }


### PR DESCRIPTION
# Bug Report

In some cases, unknown reason prevented firehose from exiting when out of memory error happened although firehose consumer was closed and exited the main thread.

## Expected Behavior
Firehose should exit when Out Of Memory error happened

## Steps to Reproduce
1. Configure bigquery or blob sink_type firehose
2. Set maximum JVM memory to -Xmx200m
3. Run firehose until OOM error shown


