### PR TITLE
refactor: handle null value of startExecutionTime inside abstract sink

### DIFF
--- a/src/main/java/io/odpf/firehose/metrics/Instrumentation.java
+++ b/src/main/java/io/odpf/firehose/metrics/Instrumentation.java
@@ -155,8 +155,9 @@ public class Instrumentation {
 
     // ================ SinkExecutionTelemetry ================
 
-    public void startExecution() {
+    public Instant startExecution() {
         startExecutionTime = Instant.now();
+        return startExecutionTime;
     }
 
     /**

--- a/src/test/java/io/odpf/firehose/metrics/InstrumentationTest.java
+++ b/src/test/java/io/odpf/firehose/metrics/InstrumentationTest.java
@@ -122,6 +122,12 @@ public class InstrumentationTest {
     }
 
     @Test
+    public void shouldReturnStartExecutionTime() {
+        Instant time = instrumentation.startExecution();
+        Assert.assertEquals(instrumentation.getStartExecutionTime().getEpochSecond(), time.getEpochSecond());
+    }
+
+    @Test
     public void shouldCaptureLifetimeTillSink() {
         List<Message> messages = Collections.singletonList(message);
         instrumentation.capturePreExecutionLatencies(messages);

--- a/src/test/java/io/odpf/firehose/sink/AbstractSinkTest.java
+++ b/src/test/java/io/odpf/firehose/sink/AbstractSinkTest.java
@@ -13,8 +13,12 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public class AbstractSinkTest {
     private static class TestSink extends AbstractSink {
@@ -57,6 +61,7 @@ public class AbstractSinkTest {
 
     @Test
     public void shouldProcessMessages() {
+        when(instrumentation.startExecution()).thenReturn(Instant.now());
         TestSink sink = new TestSink(instrumentation, "TestSink");
         Message m1 = createMessage("test", "test", "test1");
         Message m2 = createMessage("test", "test", "test2");
@@ -87,6 +92,7 @@ public class AbstractSinkTest {
 
     @Test
     public void shouldProcessFailedMessages() {
+        when(instrumentation.startExecution()).thenReturn(Instant.now());
         TestSink sink = new TestSink(instrumentation, "TestSink");
         Message m1 = createMessage("test", "test", "test1");
         Message m2 = createMessage("test", "test", "test2");
@@ -129,6 +135,7 @@ public class AbstractSinkTest {
 
     @Test
     public void shouldProcessException() {
+        when(instrumentation.startExecution()).thenReturn(Instant.now());
         TestSink sink = new TestSink(instrumentation, "TestSink");
         Message m1 = createMessage("test", "test", "test1");
         Message m2 = createMessage("test", "test", "test2");
@@ -173,6 +180,26 @@ public class AbstractSinkTest {
             add(m3);
             add(m4);
         }});
+    }
+
+    @Test
+    public void shouldNotCaptureSinkExecutionTelemetry() {
+        TestSink sink = new TestSink(instrumentation, "TestSink");
+        Message m1 = createMessage("test", "test", "test1");
+        Message m2 = createMessage("test", "test", "test2");
+        Message m3 = createMessage("test", "test", "test3");
+        Message m4 = createMessage("test", "test", "test4");
+        sink.shouldThrowException = true;
+        try {
+            sink.pushMessage(new ArrayList<Message>() {{
+            add(m1);
+            add(m2);
+            add(m3);
+            add(m4);
+        }});
+        } catch (Exception e) {
+            Mockito.verify(instrumentation, Mockito.times(0)).captureSinkExecutionTelemetry(any(), any());
+        }
     }
 
 }

--- a/src/test/java/io/odpf/firehose/sink/jdbc/JdbcSinkTest.java
+++ b/src/test/java/io/odpf/firehose/sink/jdbc/JdbcSinkTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -49,6 +50,7 @@ public class JdbcSinkTest {
     public void setUp() throws SQLException {
         when(jdbcConnectionPool.getConnection()).thenReturn(connection);
         when(connection.createStatement()).thenReturn(statement);
+        when(instrumentation.startExecution()).thenReturn(Instant.now());
         jdbcSink = new JdbcSink(instrumentation, "db", jdbcConnectionPool, queryTemplate, stencilClient);
     }
 

--- a/src/test/java/io/odpf/firehose/sink/redis/RedisSinkTest.java
+++ b/src/test/java/io/odpf/firehose/sink/redis/RedisSinkTest.java
@@ -11,6 +11,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import static org.mockito.Mockito.*;
 
@@ -24,6 +25,7 @@ public class RedisSinkTest {
 
     @Before
     public void setup() {
+        when(instrumentation.startExecution()).thenReturn(Instant.now());
         redis = new RedisSink(instrumentation, "redis", redisClient);
     }
 


### PR DESCRIPTION
## Change log
- Handle null value of startExecutionTIme inside abstract sink
- instrumentation.startExecution() now returns startExecutionTime