### PR TITLE
chore: enables blank issue template and adds slack channels links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Help
-    url: https://github.com/odpf/firehose/discussions/new?category=q-a
+    url: https://odpf-community.slack.com/archives/C01LMME51QC
     about: "If you have a question or need help, ask a question on the discussion forums."
   - name: Show and tell
-    url: https://github.com/odpf/firehose/discussions/new?category=show-and-tell
+    url: https://odpf-community.slack.com/archives/C01LCE0CYQM
     about: "Have something nice to show and tell? We'd love to hear it!"


### PR DESCRIPTION
Changes the PR template to enable blank issues. Also updates the links to point to slack community