### PR TITLE
feature: introduce config to set input data type protobuf or json and implement log sink for json

### DIFF
--- a/env/local.properties
+++ b/env/local.properties
@@ -10,6 +10,7 @@
 #
 # KAFKA_RECORD_PARSER_MODE=message
 # SINK_TYPE=log
+# INPUT_DATA_TYPE=protobuf
 # INPUT_SCHEMA_PROTO_CLASS=com.tests.TestMessage
 # INPUT_SCHEMA_PROTO_TO_COLUMN_MAPPING={"1":"order_number","2":"event_timestamp","3":"driver_id"}
 # METRIC_STATSD_HOST=localhost
@@ -33,7 +34,7 @@
 # SCHEMA_REGISTRY_STENCIL_FETCH_AUTH_BEARER_TOKEN=tcDpw34J8d1
 # SCHEMA_REGISTRY_STENCIL_CACHE_AUTO_REFRESH=false
 # SCHEMA_REGISTRY_STENCIL_CACHE_TTL_MS=900000
-# 
+#
 #
 #############################################
 #

--- a/src/main/java/io/odpf/firehose/config/AppConfig.java
+++ b/src/main/java/io/odpf/firehose/config/AppConfig.java
@@ -1,9 +1,11 @@
 package io.odpf.firehose.config;
 
+import io.odpf.firehose.config.converter.InputDataTypeConverter;
 import io.odpf.firehose.config.converter.ProtoIndexToFieldMapConverter;
 import io.odpf.firehose.config.converter.SchemaRegistryHeadersConverter;
 import io.odpf.firehose.config.converter.SchemaRegistryRefreshConverter;
 import io.odpf.firehose.config.converter.SinkTypeConverter;
+import io.odpf.firehose.config.enums.InputDataType;
 import io.odpf.firehose.config.enums.SinkType;
 import io.odpf.stencil.cache.SchemaRefreshStrategy;
 
@@ -30,6 +32,11 @@ public interface AppConfig extends Config {
     @Key("SINK_TYPE")
     @ConverterClass(SinkTypeConverter.class)
     SinkType getSinkType();
+
+    @Key("INPUT_DATA_TYPE")
+    @ConverterClass(InputDataTypeConverter.class)
+    @DefaultValue("PROTOBUF")
+    InputDataType getInputDataTye();
 
     @Key("APPLICATION_THREAD_COUNT")
     @DefaultValue("1")

--- a/src/main/java/io/odpf/firehose/config/converter/InputDataTypeConverter.java
+++ b/src/main/java/io/odpf/firehose/config/converter/InputDataTypeConverter.java
@@ -1,0 +1,13 @@
+package io.odpf.firehose.config.converter;
+
+import io.odpf.firehose.config.enums.InputDataType;
+import org.aeonbits.owner.Converter;
+
+import java.lang.reflect.Method;
+
+public class InputDataTypeConverter implements Converter {
+    @Override
+    public InputDataType convert(Method method, String input) {
+        return InputDataType.valueOf(input.toUpperCase());
+    }
+}

--- a/src/main/java/io/odpf/firehose/config/enums/InputDataType.java
+++ b/src/main/java/io/odpf/firehose/config/enums/InputDataType.java
@@ -1,0 +1,6 @@
+package io.odpf.firehose.config.enums;
+
+public enum InputDataType {
+    PROTOBUF,
+    JSON
+}

--- a/src/test/java/io/odpf/firehose/config/AppConfigTest.java
+++ b/src/test/java/io/odpf/firehose/config/AppConfigTest.java
@@ -1,0 +1,38 @@
+package io.odpf.firehose.config;
+
+import io.odpf.firehose.config.enums.InputDataType;
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppConfigTest {
+
+    @Test
+    public void getInputDataTypeProtoBuf() {
+        // when default
+        AppConfig appConfig = ConfigFactory.create(AppConfig.class, Collections.emptyMap());
+        InputDataType defaultDataType = appConfig.getInputDataTye();
+        assertEquals(InputDataType.PROTOBUF, defaultDataType);
+
+        //when explicitly set as protobuf
+        Map<Object, Object> configMap = new HashMap<>();
+        configMap.put("INPUT_DATA_TYPE", "protobuf");
+        AppConfig appConfigExplicit = ConfigFactory.create(AppConfig.class, configMap);
+        InputDataType protobufDataType = appConfigExplicit.getInputDataTye();
+        assertEquals(InputDataType.PROTOBUF, protobufDataType);
+    }
+
+    @Test
+    public void getInputDataTypeJson() {
+        Map<Object, Object> configMap = new HashMap<>();
+        configMap.put("INPUT_DATA_TYPE", "json");
+        AppConfig appConfig = ConfigFactory.create(AppConfig.class, configMap);
+        InputDataType defaultDataType = appConfig.getInputDataTye();
+        assertEquals(InputDataType.JSON, defaultDataType);
+    }
+}


### PR DESCRIPTION
This PR formally introduces support json input data type  #84 

1. Have introduced new config called INPUT_DATA_TYPE with default value as protobuf. 
2. The available values for the above config are json or protobuf.
3. Implement LogSink for Json data