### PR TITLE
docs: docs for support bq sink clustering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage:1.114.0'
     implementation 'com.google.cloud:google-cloud-bigquery:1.115.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    implementation group: 'io.odpf', name: 'depot', version: '0.3.0'
+    implementation group: 'io.odpf', name: 'depot', version: '0.2.1'
     implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.59' exclude group: 'org.slf4j'
 
     testImplementation group: 'junit', name: 'junit', version: '4.11'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'io.odpf'
-version '0.4.1'
+version '0.4.2'
 
 def projName = "firehose"
 
@@ -101,7 +101,7 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage:1.114.0'
     implementation 'com.google.cloud:google-cloud-bigquery:1.115.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    implementation group: 'io.odpf', name: 'depot', version: '0.2.0'
+    implementation group: 'io.odpf', name: 'depot', version: '0.3.0'
     implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.59' exclude group: 'org.slf4j'
 
     testImplementation group: 'junit', name: 'junit', version: '4.11'

--- a/docs/docs/sinks/bigquery-sink.md
+++ b/docs/docs/sinks/bigquery-sink.md
@@ -32,6 +32,10 @@ For type conversion between protobuf to bigquery type. Please refer to
 Bigquery Sink supports creation of table with partition configuration.
 For more information refer to [Depot-bigquery.md#partitioning section](https://github.com/odpf/depot/blob/main/docs/sinks/bigquery.md#partitioning)
 
+## Clustering
+Bigquery Sink supports for creating and modifying clustered or unclustered table with clustering configuration.
+For more information refer to [Depot-bigquery.md#clustering section](https://github.com/odpf/depot/blob/main/docs/sinks/bigquery.md#clustering)
+
 ## Kafka Metadata
 For data quality checking purpose sometimes kafka metadata need to be added on the record. For more information refer to [Depot-bigquery.md#metadata sectionn](https://github.com/odpf/depot/blob/main/docs/sinks/bigquery.md#metadata)
 


### PR DESCRIPTION
Bump up depot version which supports for BigQuery sink table clustering.
In this version, BigQuery sink will support for creating and modifying clustered tables.

How to use:

Add this configuration for enabling bigquery sink table clustering.
```
SINK_BIGQUERY_TABLE_CLUSTERING_ENABLE=true
SINK_BIGQUERY_TABLE_CLUSTERING_KEYS=column_name1,column_name2,column_name3,column_name4
```
Follow [this](https://github.com/odpf/depot/blob/main/docs/sinks/bigquery.md#clustering) for more details.

- [x] Bump up depot version
- [x] Bump up firehose version
- [x] Added BigQuery sink table clustering documentation