### PR TITLE
fix: prom sink changed to PoolingHttpClientConnectionManager for idle connection eviction

### DIFF
--- a/docs/docs/sinks/prometheus-sink.md
+++ b/docs/docs/sinks/prometheus-sink.md
@@ -23,6 +23,7 @@ Defines the maximum number of HTTP connections with Prometheus.
 
 - Example value: `10`
 - Type: `optional`
+- Default value: `default no more than 2 concurrent connections per given route and no more 20 connections`
 
 ### `SINK_PROM_RETRY_STATUS_CODE_RANGES`
 

--- a/docs/docs/sinks/prometheus-sink.md
+++ b/docs/docs/sinks/prometheus-sink.md
@@ -21,9 +21,9 @@ Defines the connection timeout for the request in millis.
 
 Defines the maximum number of HTTP connections with Prometheus.
 
-- Example value: `5`
+- Example value: `10`
 - Type: `required`
-- Default value: `5`
+- Default value: `10`
 
 ### `SINK_PROM_RETRY_STATUS_CODE_RANGES`
 

--- a/docs/docs/sinks/prometheus-sink.md
+++ b/docs/docs/sinks/prometheus-sink.md
@@ -22,8 +22,7 @@ Defines the connection timeout for the request in millis.
 Defines the maximum number of HTTP connections with Prometheus.
 
 - Example value: `10`
-- Type: `required`
-- Default value: `10`
+- Type: `optional`
 
 ### `SINK_PROM_RETRY_STATUS_CODE_RANGES`
 

--- a/docs/docs/sinks/prometheus-sink.md
+++ b/docs/docs/sinks/prometheus-sink.md
@@ -17,6 +17,14 @@ Defines the connection timeout for the request in millis.
 - Type: `required`
 - Default value: `10000`
 
+### `SINK_PROM_MAX_CONNECTIONS`
+
+Defines the maximum number of HTTP connections with Prometheus.
+
+- Example value: `5`
+- Type: `required`
+- Default value: `5`
+
 ### `SINK_PROM_RETRY_STATUS_CODE_RANGES`
 
 Defines the range of HTTP status codes for which retry will be attempted.

--- a/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
+++ b/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
@@ -23,7 +23,6 @@ public interface PromSinkConfig extends AppConfig {
     Integer getSinkPromRequestTimeoutMs();
 
     @Key("SINK_PROM_MAX_CONNECTIONS")
-    @DefaultValue("10")
     Integer getSinkPromMaxConnections();
 
     @Key("SINK_PROM_SERVICE_URL")

--- a/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
+++ b/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
@@ -22,6 +22,10 @@ public interface PromSinkConfig extends AppConfig {
     @DefaultValue("10000")
     Integer getSinkPromRequestTimeoutMs();
 
+    @Key("SINK_PROM_MAX_CONNECTIONS")
+    @DefaultValue("5")
+    Integer getSinkPromMaxConnections();
+
     @Key("SINK_PROM_SERVICE_URL")
     String getSinkPromServiceUrl();
 

--- a/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
+++ b/src/main/java/io/odpf/firehose/config/PromSinkConfig.java
@@ -23,7 +23,7 @@ public interface PromSinkConfig extends AppConfig {
     Integer getSinkPromRequestTimeoutMs();
 
     @Key("SINK_PROM_MAX_CONNECTIONS")
-    @DefaultValue("5")
+    @DefaultValue("10")
     Integer getSinkPromMaxConnections();
 
     @Key("SINK_PROM_SERVICE_URL")

--- a/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
+++ b/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
@@ -68,7 +68,7 @@ public class PromSinkFactory {
                 .setConnectionRequestTimeout(promSinkConfig.getSinkPromRequestTimeoutMs())
                 .setConnectTimeout(promSinkConfig.getSinkPromRequestTimeoutMs()).build();
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        if(promSinkConfig.getSinkPromMaxConnections() != null && promSinkConfig.getSinkPromMaxConnections() > 0){
+        if (promSinkConfig.getSinkPromMaxConnections() != null && promSinkConfig.getSinkPromMaxConnections() > 0) {
             connectionManager.setMaxTotal(promSinkConfig.getSinkPromMaxConnections());
             connectionManager.setDefaultMaxPerRoute(promSinkConfig.getSinkPromMaxConnections());
         }

--- a/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
+++ b/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
@@ -64,13 +64,14 @@ public class PromSinkFactory {
      * @return CloseableHttpClient
      */
     private static CloseableHttpClient newHttpClient(PromSinkConfig promSinkConfig) {
-        Integer maxPromConnections = promSinkConfig.getSinkPromMaxConnections();
         RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(promSinkConfig.getSinkPromRequestTimeoutMs())
                 .setConnectionRequestTimeout(promSinkConfig.getSinkPromRequestTimeoutMs())
                 .setConnectTimeout(promSinkConfig.getSinkPromRequestTimeoutMs()).build();
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setMaxTotal(maxPromConnections);
-        connectionManager.setDefaultMaxPerRoute(maxPromConnections);
+        if(promSinkConfig.getSinkPromMaxConnections() != null && promSinkConfig.getSinkPromMaxConnections() > 0){
+            connectionManager.setMaxTotal(promSinkConfig.getSinkPromMaxConnections());
+            connectionManager.setDefaultMaxPerRoute(promSinkConfig.getSinkPromMaxConnections());
+        }
 
         HttpClientBuilder builder = HttpClients.custom().setConnectionManager(connectionManager).setDefaultRequestConfig(requestConfig);
 

--- a/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
+++ b/src/main/java/io/odpf/firehose/sink/prometheus/PromSinkFactory.java
@@ -13,7 +13,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
 import java.util.Map;
 
@@ -64,10 +64,14 @@ public class PromSinkFactory {
      * @return CloseableHttpClient
      */
     private static CloseableHttpClient newHttpClient(PromSinkConfig promSinkConfig) {
+        Integer maxPromConnections = promSinkConfig.getSinkPromMaxConnections();
         RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(promSinkConfig.getSinkPromRequestTimeoutMs())
                 .setConnectionRequestTimeout(promSinkConfig.getSinkPromRequestTimeoutMs())
                 .setConnectTimeout(promSinkConfig.getSinkPromRequestTimeoutMs()).build();
-        BasicHttpClientConnectionManager connectionManager = new BasicHttpClientConnectionManager();
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(maxPromConnections);
+        connectionManager.setDefaultMaxPerRoute(maxPromConnections);
+
         HttpClientBuilder builder = HttpClients.custom().setConnectionManager(connectionManager).setDefaultRequestConfig(requestConfig);
 
         return builder.build();


### PR DESCRIPTION
We have recently started using Prom Sink, We are seeing NoHttpResponseException in log-

`2022-09-28T12:20:59,632Z [pool-2-thread-1] WARN  i.o.f.sink.prometheus.PromSink - caught class org.apache.http.NoHttpResponseException p-gopaydata-id-radar-router.gtfdata.io:80 failed to respond
2022-09-28T12:20:59,632Z [pool-2-thread-1] WARN  i.o.f.sink.prometheus.PromSink - xxxxxxxxxxxxxxx.gtfdata.io:80 failed to respond
org.apache.http.NoHttpResponseException: xxxxxxxxxxxxxxxxxx.gtfdata.io:80 failed to respond
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:141)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)`

Fix - PoolingHttpClientConnectionManager will evict partially closed connection by default. 

