### PR TITLE
Fix parsing for midday cycle.

### DIFF
--- a/src/main/java/io/odpf/firehose/serializer/MessageToJson.java
+++ b/src/main/java/io/odpf/firehose/serializer/MessageToJson.java
@@ -114,7 +114,7 @@ public class MessageToJson implements MessageSerializer {
 
         Date date;
         try {
-            date = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss").parse(timestampObject);
+            date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(timestampObject);
         } catch (java.text.ParseException e) {
             throw new RuntimeException(String.format("Not able to parse date, %s", timestampObject));
         }

--- a/src/test/java/io/odpf/firehose/serializer/MessageToJsonTest.java
+++ b/src/test/java/io/odpf/firehose/serializer/MessageToJsonTest.java
@@ -43,6 +43,24 @@ public class MessageToJsonTest {
     }
 
     @Test
+    public void shouldProperlyHandleMiddayCycle() throws DeserializerException {
+        MessageToJson messageToJson = new MessageToJson(protoParser, false, true);
+
+        String logMessageWithMidday = "CgYI9/7PoQYSBgiz/8+hBhgNIICAgIDA9/y0LigCMAM\u003d";
+        String logKeyWithMidday = "CgYI9/7PoQYSBgiz/8+hBhgNIICAgIDA9/y0LigC";
+        Message message = new Message(Base64.getDecoder().decode(logKeyWithMidday.getBytes()),
+                Base64.getDecoder().decode(logMessageWithMidday.getBytes()), "sample-topic", 0, 100);
+        String actualOutput = messageToJson.serialize(message);
+        assertEquals(actualOutput, "{\"logMessage\":\"{\\\"uniqueDrivers\\\":\\\"3\\\","
+                + "\\\"windowStartTime\\\":\\\"Apr 10, 2023 12:22:15 PM\\\","
+                + "\\\"windowEndTime\\\":\\\"Apr 10, 2023 12:23:15 PM\\\",\\\"s2IdLevel\\\":13,\\\"vehicleType\\\":\\\"BIKE\\\","
+                + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\",\"topic\":\"sample-topic\",\"logKey\":\"{"
+                + "\\\"windowStartTime\\\":\\\"Apr 10, 2023 12:22:15 PM\\\","
+                + "\\\"windowEndTime\\\":\\\"Apr 10, 2023 12:23:15 PM\\\",\\\"s2IdLevel\\\":13,\\\"vehicleType\\\":\\\"BIKE\\\","
+                + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\"}");
+    }
+
+    @Test
     public void shouldSerializeWhenKeyIsMissing() throws DeserializerException {
         MessageToJson messageToJson = new MessageToJson(protoParser, false, true);
 


### PR DESCRIPTION
## Fix JSON parsing for midday cycle
The current way of converting Protobuf timestamp into JSON object is erroneous due to wrong date pattern.

For example:
input: `2023-04-10T12:22:15`
expected output: `Apr 10, 2023 12:22:15 PM`
actual output: `Apr 10, 2023 12:22:15 AM`

This PR fixes the issue above.

#### :heavy_check_mark: Checklist
<!--- Please include the following in your Pull Request when applicable: -->

- [x] Tests for new functionality and regression tests for bug fixes